### PR TITLE
updated the function call "bind(fd, (struct sockaddr*) &addr, sizeof(addr))" to "::bind(~, ~, ~)" in client.cpp file

### DIFF
--- a/client.cpp
+++ b/client.cpp
@@ -101,7 +101,7 @@ int makeConnection(int connfd_server, string filename)
 	addr.sin_family	= AF_INET;
 	addr.sin_port		= htons(0);	//zero chooses a free port
 
-	if (bind(fd, (struct sockaddr*) &addr, sizeof(addr)) == -1) {
+	if (::bind(fd, (struct sockaddr*) &addr, sizeof(addr)) == -1) {
 		perror("Bind failed on socket\n");
 		return -1;	
 	}


### PR DESCRIPTION
It is done so that the compiler wouldn't get confused between bind() defined in <bind.h> and <socket.h>... on my Mac OS environment I got an error while trying to compile the client.cpp file. 

1. The bind(~, ~, ~) defined in <bind.h> returns '__bind<int &, sockaddr *, unsigned long>' rather than an 'int'.
2. The bind(~, ~, ~) defined in <socket.h> returns an 'int'. '0' on success and '-1' on failure.

error message is as follows:
./client.cpp:104:55: error: invalid operands to binary expression ('__bind<int &, sockaddr *, unsigned long>' and 'int')
        if (bind(fd, (struct sockaddr*) &addr, sizeof(addr)) == -1) {
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~