### PR TITLE
updated server.cpp as well, but one additional change was made

### DIFF
--- a/server.cpp
+++ b/server.cpp
@@ -25,11 +25,11 @@ struct client
 		serial = s;
 		fd = f;
 	}
-	bool operator ==(const client& obj)	//overloading operators for list operations
+	bool operator ==(const client& obj) const	//overloading operators for list operations
 	{
 		return obj.serial == serial;
 	}
-	bool operator !=(const client& obj)
+	bool operator !=(const client& obj) const
 	{
 		return obj.serial != serial;
 	}
@@ -178,7 +178,7 @@ int main() {
 	addr.sin_family	= AF_INET;
 	addr.sin_port		= htons(SERVER_PORT_NO);
 
-	if (bind(fd, (struct sockaddr*) &addr, sizeof(addr)) == -1) {
+	if (::bind(fd, (struct sockaddr*) &addr, sizeof(addr)) == -1) {
 		perror("Bind failed on socket\n");
 		return -1;	
 	}


### PR DESCRIPTION
i changed the "bind(~, ~, ~)" to "::bind(~, ~, ~)" similar to the change made in client.cpp file. 

the one additional change is made in the overloading of the operators "==" and "!=" to tell the compiler that these operators are read-only. otherwise, I was getting errors regarding "==" operator.

error messages are as follows:
In file included from ./server.cpp:8:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/list:2160:18: error: invalid operands to binary expression ('const std::__list_const_iterator<client, void *>::value_type' (aka 'const client') and 'const std::list<client>::value_type' (aka 'const client'))
        if (*__i == __x)
          ~~~~~ ^  ~~~
./server.cpp:53:12: note: in instantiation of member function 'std::list<client>::remove' requested here
                        clients.remove(obj);    //remove client from list
                       ~~~~~^~~~

even though the above messages were only for "==" operator but the changes should be made to "!=" operator as well.